### PR TITLE
Find unused parameters

### DIFF
--- a/models/reinforce_model/model_with_inferencenw.py
+++ b/models/reinforce_model/model_with_inferencenw.py
@@ -130,9 +130,6 @@ class LatentVariableInferenceModel(nn.Module):
                 log_prob_x_z_given_h = ll_lm
                 if self.training_type == TRAINING_TYPE_MARGINALIZE:
                     log_prob_x_z_given_h += torch.log(z_given_h[:, i])  # B
-                print("log_prob_x_z_given_h = ", log_prob_x_z_given_h)
-                print("num_labels = ", num_labels)
-                print("log_prob_x_z_given_h/num_labels = ", log_prob_x_z_given_h / num_labels)
 
                 log_probs_lm.append(log_prob_x_z_given_h / num_labels)  # This line is trhowing error
 

--- a/models/reinforce_model/train.py
+++ b/models/reinforce_model/train.py
@@ -146,7 +146,7 @@ def train():
         from apex import amp  # Apex is only required if we use fp16 training
         model, optimizer = amp.initialize(model, optimizer, opt_level=args.fp16)
     if args.distributed:
-        model = DistributedDataParallel(model, device_ids=[args.local_rank], output_device=args.local_rank)
+        model = DistributedDataParallel(model, device_ids=[args.local_rank], output_device=args.local_rank, find_unused_parameters=True)
 
     print("Prepare datasets")
     start = datetime.now()


### PR DESCRIPTION
Set `find_unused_parameters` argument of `DistributedDataParallel` to `True`. Remove debug prints.