### PR TITLE
Make multiple fixes until it works

### DIFF
--- a/models/reinforce_model/dataset.py
+++ b/models/reinforce_model/dataset.py
@@ -16,8 +16,16 @@ ROBERTA_START = 2
 SPECIAL_TOKENS = ["<bos>", "<eos>", "<speaker1>", "<speaker2>", "<pad>"]
 ATTR_TO_SPECIAL_TOKEN = {'bos_token': '<bos>', 'eos_token': '<eos>', 'pad_token': '<pad>',
                          'additional_special_tokens': ['<speaker1>', '<speaker2>']}
-MODEL_INPUTS = ["input_ids", "mc_token_ids", "lm_labels", "mc_labels", "token_type_ids"]
-PADDED_INPUTS = ["input_ids", "lm_labels", "token_type_ids"]
+MODEL_INPUTS = [
+    "input_ids",
+    "token_type_ids",
+    "mc_token_ids",
+    "lm_labels",
+    "mc_labels",
+    "persona",
+    "history",
+    "effects",
+]
 EFFECTS = {
     'oEffect': 1,
     'oReact': 2,
@@ -36,12 +44,6 @@ PERSONA_MAX_LENGTH = 50
 MAX_NUM_PERSONA = 5
 MAX_NUM_COMET_PERSONA = 250
 
-def pad_dataset(dataset, padding=0):
-    """ Pad the dataset. This could be optimized by defining a Dataset class and padding at the batch level, but this is simpler. """
-    max_l = max(len(x) for x in dataset["input_ids"])
-    for name in PADDED_INPUTS:
-        dataset[name] = [x + [padding if name != "lm_labels" else -100] * (max_l - len(x)) for x in dataset[name]]
-    return dataset
 
 def build_input_from_segments(persona, history, reply, tokenizer, lm_labels=False, with_eos=True):
     """ Build a sequence of input from 3 segments: persona, history and last reply. """
@@ -60,26 +62,6 @@ def build_input_from_segments(persona, history, reply, tokenizer, lm_labels=Fals
         instance["lm_labels"] = ([-100] * sum(len(s) for s in sequence[:-1])) + [-100] + sequence[-1][1:]
     return instance
 
-    # print("Pad inputs and convert to Tensor")
-    # tensor_datasets = {"train": [], "valid": []}
-    # for dataset_name, dataset in datasets.items():
-    #     dataset = pad_dataset(dataset, padding=tokenizer.convert_tokens_to_ids(SPECIAL_TOKENS[-1]))
-    #     for input_name in MODEL_INPUTS:
-    #         tensor = torch.tensor(dataset[input_name])
-    #         if input_name != "mc_labels":
-    #             tensor = tensor.view((-1, datasets[dataset_name]["n_candidates"]) + tensor.shape[1:])
-    #         tensor_datasets[dataset_name].append(tensor)
-
-    # print("Build train and validation dataloaders")
-    # train_dataset, valid_dataset = TensorDataset(*tensor_datasets["train"]), TensorDataset(*tensor_datasets["valid"])
-    # train_sampler = torch.utils.data.distributed.DistributedSampler(train_dataset) if args.distributed else None
-    # valid_sampler = torch.utils.data.distributed.DistributedSampler(valid_dataset) if args.distributed else None
-    # train_loader = DataLoader(train_dataset, sampler=train_sampler, batch_size=args.train_batch_size, shuffle=(not args.distributed))
-    # valid_loader = DataLoader(valid_dataset, sampler=valid_sampler, batch_size=args.valid_batch_size, shuffle=False)
-
-    # print("Train dataset (Batch, Candidates, Seq length): {}".format(train_dataset.tensors[0].shape))
-    # print("Valid dataset (Batch, Candidates, Seq length): {}".format(valid_dataset.tensors[0].shape))
-    # return train_loader, valid_loader, train_sampler, valid_sampler
 
 class PersonaChatDataset(Dataset):
     def __init__(
@@ -92,7 +74,7 @@ class PersonaChatDataset(Dataset):
             **kwargs,
     ):
         super().__init__()
-
+        [self.pad_id] = tokenizer.convert_tokens_to_ids(["<pad>"])
         self.split = split
         self.length = 0
 
@@ -104,7 +86,7 @@ class PersonaChatDataset(Dataset):
         personachat = get_dataset(tokenizer, args.dataset_path, args.dataset_cache)
         print("Build inputs and labels for {}".format(split))
 
-        self.dataset = defaultdict(list)
+        self.dataset = {n: [] for n in MODEL_INPUTS}
         # for dataset_name, dataset in personachat.items():
         personachat_split = personachat[split]
         num_candidates = len(personachat_split[0]["utterances"][0]["candidates"])
@@ -160,9 +142,6 @@ class PersonaChatDataset(Dataset):
 
                     self.dataset["persona"].append([[ROBERTA_START] + p  for p in persona])
                     self.dataset["history"].append([ROBERTA_START] + list(chain(*history)))
-                    history_folded = kwargs.get('history_folded', False)
-                    if history_folded:
-                        self.dataset["history_folded"].append(history)
                     self.dataset["n_candidates"] = num_candidates
                     assert len(persona) == len(effects)
                     self.dataset["effects"].append(effects) 
@@ -192,74 +171,52 @@ class PersonaChatDataset(Dataset):
         '''
 
         multiplier = self.dataset['n_candidates'] * self.max_num_persona
-        items = []
+        sample = {}
         for name in self.dataset.keys():
-            if name not in ['n_candidates', 'mc_labels', 'persona', 'history', 'history_folded', 'effects']:
-                item = [self.dataset[name][index*multiplier:(index+1)*multiplier]]
-                items.append(item)
+            if name in ['mc_token_ids', 'input_ids', 'token_type_ids', 'lm_labels']:
+                sample[name] = self.dataset[name][index*multiplier:(index+1)*multiplier]
             elif name  == 'mc_labels':
-                items.append(self.dataset[name][index*self.max_num_persona:(index+1)*self.max_num_persona])
-            elif name in ['persona', 'history', 'history_folded', 'effects']:
-                items.append(self.dataset[name][index])
+                sample[name] = self.dataset[name][index*self.max_num_persona:(index+1)*self.max_num_persona]
+            elif name in ['persona', 'history', 'effects']:
+                sample[name] = self.dataset[name][index]
             elif name == 'n_candidates':
-                items.append(self.dataset[name])
-        
-        if 'history_folded' in self.dataset.keys():
-            input_ids, token_type_ids, mc_token_ids, lm_labels, mc_labels, persona, history, history_folded, n_candidates, effects = items
-            return input_ids, token_type_ids, mc_token_ids, lm_labels, mc_labels, persona, history, history_folded, n_candidates, effects
-        else:
-            input_ids, token_type_ids, mc_token_ids, lm_labels, mc_labels, persona, history, n_candidates, effects = items
-            return input_ids, token_type_ids, mc_token_ids, lm_labels, mc_labels, persona, history, n_candidates, effects
+                sample[name] = self.dataset[name]
+            else:
+                assert False, f"Unexpected dataset element with name '{name}'"
+        return sample
 
-def collate_dialog(batch, max_num_persona=5):
-    '''
-    Padding and Collating
-    '''
-    input_ids, token_type_ids, mc_token_ids, lm_labels, mc_labels, persona, history, n_candidates, effects = zip(*batch)
-    n_candidates = n_candidates[0]
-
-    max_seq_len = 0
-    for b in input_ids:
-        for c in b[0]:
-            max_seq_len = max(max_seq_len, len(c))
-
-    padded_input_ids = torch.LongTensor([
-        [c + [0]*(max_seq_len - len(c)) for c in seq[0]]
-        for seq in input_ids])
-    padded_input_ids = padded_input_ids.view((-1, max_num_persona, n_candidates) + padded_input_ids.shape[2:])
-
-    padded_token_type_ids = torch.LongTensor([
-        [c + [0]*(max_seq_len - len(c)) for c in seq[0]]
-        for seq in token_type_ids])
-    padded_token_type_ids = padded_token_type_ids.view((-1, max_num_persona, n_candidates) + padded_token_type_ids.shape[2:])
-    
-    padded_lm_labels = torch.LongTensor([
-        [c + [-100]*(max_seq_len - len(c)) for c in seq[0]]
-        for seq in lm_labels])
-    padded_lm_labels = padded_lm_labels.view((-1, max_num_persona, n_candidates) + padded_lm_labels.shape[2:])
-
-    mc_token_ids = torch.LongTensor(mc_token_ids).squeeze(1)
-    mc_token_ids = mc_token_ids.view((-1, max_num_persona, n_candidates))
-    mc_labels = torch.LongTensor(mc_labels)
-
-    # persona
-    max_persona_len = 0
-    for b in persona:
-        for p in b:
-            max_persona_len = max(max_persona_len, len(p))
-
-    padded_persona = torch.LongTensor([[p + [0]*(max_persona_len - len(p)) for p in b] for b in persona])
-
-    # history
-    max_history_len = 0
-    for b in history:
-        max_history_len = max(max_history_len, len(b))
-    padded_history = torch.LongTensor([b + [0]*(max_history_len - len(b)) for b in history])
-
-    padded_effects = torch.LongTensor(effects)
-
-    return padded_input_ids, padded_token_type_ids, padded_lm_labels, \
-        mc_token_ids, mc_labels, padded_persona, padded_history, padded_effects
+    def collate_dialog(self, batch, max_num_persona=5):
+        '''
+        Padding and Collating
+        '''
+        max_seq_len = max(len(c) for b in batch for c in b['input_ids'])
+        max_persona_len = max(len(p) for b in batch for p in b['persona'])
+        max_history_len = max(len(b['history']) for b in batch)
+        n_candidates = batch[0]['n_candidates']
+        padded_batch = {}
+        for name in batch[0].keys():
+            if name in ['input_ids', 'token_type_ids']:
+                padded = torch.LongTensor([[c + [self.pad_id]*(max_seq_len - len(c)) for c in sample[name]] for sample in batch])
+                padded_batch[name] = padded.view((-1, max_num_persona, n_candidates) + padded.shape[2:])
+            elif name == 'persona': 
+                padded_batch[name] = torch.LongTensor([[p + [self.pad_id]*(max_persona_len - len(p)) for p in sample['persona']] for sample in batch])
+            elif name == 'history':
+                padded_batch[name] = torch.LongTensor([sample[name] + [self.pad_id]*(max_history_len - len(sample[name])) for sample in batch])
+            elif name == "lm_labels":
+                padded = torch.LongTensor([[c + [-100]*(max_seq_len - len(c)) for c in sample[name]] for sample in batch])
+                padded_batch[name] = padded.view((-1, max_num_persona, n_candidates) + padded.shape[2:])
+            elif name == "mc_token_ids":
+                padded_batch[name] = torch.LongTensor([sample[name] for sample in batch]).view((-1, max_num_persona, n_candidates))
+            elif name in ["mc_labels", "effects"]:
+                padded_batch[name] = torch.LongTensor([sample[name] for sample in batch])
+            elif name == "n_candidates":
+                pass
+            else:
+                assert False, f"Unexpected batch element with key '{name}'"
+        # print("PersonaChatDataset.collate_dialog:")
+        # for k, v in padded_batch.items():
+        #     print(f"{k}.shape:", v.shape)
+        return padded_batch        
 
 
 def preprocess_comet_dataset(dataset_path):

--- a/models/reinforce_model/model_with_inferencenw.py
+++ b/models/reinforce_model/model_with_inferencenw.py
@@ -25,7 +25,7 @@ class LatentVariableInferenceModel(nn.Module):
         else:
             raise Exception('Invalid prior model')
 
-        self.gpt2_model = generator_class.from_pretrained(args.model_checkpoint)
+        self.gpt2_model = generator_class.from_pretrained(args.generation_model)
         self.criterion_lm = torch.nn.CrossEntropyLoss(ignore_index=-100, reduction='none')
         self.criterion_mc = torch.nn.CrossEntropyLoss(reduction='none')
 
@@ -65,7 +65,6 @@ class LatentVariableInferenceModel(nn.Module):
         mc_labels: B
         token_type_ids: B x P x C x T
         '''
-
         effects = kwargs.get('effects', None)
 
         sampler_model = self.inference_model
@@ -193,8 +192,8 @@ class LatentVariableInferenceModel(nn.Module):
             # log_sum_exp_mc = torch.logsumexp(log_probs_mc, dim=1)  # logsumexp
             # loss_mc = -1.0 * log_sum_exp_mc.mean()
             loss_mc = torch.Tensor([0.0]).to(self.args.device)
-
-            return total_loss_lm, loss_mc, loss_prior, loss_lm, num_labels, track_rewards, kl_loss, elbo_loss_tracking
+            total_loss_lm += 0 * lm_logits.sum() + 0 * mc_logits.sum()  # Fix unsused parameter failure when DDP is used
+            return lm_logits, mc_logits, total_loss_lm, loss_mc, loss_prior, loss_lm, num_labels, track_rewards, kl_loss, elbo_loss_tracking
 
         if generate:
             lm_logits = self.gpt2_model(

--- a/models/reinforce_model/prior_posterior_models.py
+++ b/models/reinforce_model/prior_posterior_models.py
@@ -63,7 +63,7 @@ class PriorBoWModel(nn.Module):
                 batch_size, num_personas, num_tokens = persona.shape
                 persona = persona.reshape(-1, num_tokens)
                 n = batch_size * num_personas
-                n_splits = 8
+                n_splits = 1
                 if n > 1 and n_splits > 1:
                     split_size = n // n_splits
                     persona_encodings = torch.cat(
@@ -156,7 +156,7 @@ class PriorRobertaModel(nn.Module):
                 batch_size, num_personas, num_tokens = persona.shape
                 persona = persona.reshape(-1, num_tokens)
                 n = batch_size * num_personas
-                n_splits = 8
+                n_splits = 1
                 if n > 1 and n_splits > 1:
                     split_size = n // n_splits
                     persona_encodings = torch.cat(
@@ -239,7 +239,7 @@ class InferenceRobertaModel(nn.Module):
                 batch_size, num_personas, num_tokens = persona.shape
                 persona = persona.reshape(-1, num_tokens)
                 n = batch_size * num_personas
-                n_splits = 8
+                n_splits = 1
                 if n > 1 and n_splits > 1:
                     split_size = n // n_splits
                     persona_encodings = torch.cat(

--- a/models/reinforce_model/prior_posterior_models.py
+++ b/models/reinforce_model/prior_posterior_models.py
@@ -55,37 +55,53 @@ class PriorBoWModel(nn.Module):
             return prob_z_given_H.to(self.args.device)
 
         else:
-            history_encodings = self.roberta_embeddings(history).mean(dim=1)  # B x 764
-            history_encodings = self.history_tranformation(history_encodings) # B x 764
-            history_encodings = history_encodings.unsqueeze(1).repeat(1, persona.shape[1], 1)  # B x P x 764
+            try:
+                history_encodings = self.roberta_embeddings(history).mean(dim=1)  # B x 764
+                history_encodings = self.history_tranformation(history_encodings) # B x 764
+                history_encodings = history_encodings.unsqueeze(1).repeat(1, persona.shape[1], 1)  # B x P x 764
 
-            batch_size, num_personas, num_tokens = persona.shape
-            persona = persona.reshape(-1, num_tokens)
-            persona_encodings = self.roberta_embeddings(persona).mean(dim=1).reshape(batch_size, num_personas, -1)
+                batch_size, num_personas, num_tokens = persona.shape
+                persona = persona.reshape(-1, num_tokens)
+                n = batch_size * num_personas
+                n_splits = 8
+                if n > 1 and n_splits > 1:
+                    split_size = n // n_splits
+                    persona_encodings = torch.cat(
+                        [
+                             self.roberta_embeddings(persona[i*split_size:(i+1)*split_size, :]) 
+                             for i in range(n_splits-1)
+                        ]
+                        + [self.roberta_embeddings(persona[(n_splits-1)*split_size:, :])],
+                        dim=0,
+                    ).mean(dim=1).reshape(batch_size, num_personas, -1)
+                persona_encodings = self.roberta_embeddings(persona).mean(dim=1).reshape(batch_size, num_personas, -1)
 
 
-            feats = -1.0 * torch.norm(history_encodings - persona_encodings, 2, dim=-1)
-            # print("feats : ", feats.size())
-
-            if self.use_structured_prior:
-                embs = self.effect_type_emb(effects) # B,P,emsize
-                effect_feature = self.effect_type_to_feature(embs) # B,P,1
-                # print(torch.exp(effect_feature, dim=-1)) --> sort and analyze
+                feats = -1.0 * torch.norm(history_encodings - persona_encodings, 2, dim=-1)
                 # print("feats : ", feats.size())
-                # print("effect_feature : ", effect_feature.size())
-                if self.use_structured_prior_binarypotential:
-                    effecthistory_feature = self.effecthistory_type_to_feature(
-                        torch.cat([embs,history_encodings],dim=2)) # B,P,1
-                    feats = torch.cat([feats.unsqueeze(2), effect_feature,effecthistory_feature], dim=2)  # B,P,num_feats
-                else:
-                    feats = torch.cat([feats.unsqueeze(2), effect_feature], dim=2)  # B,P,num_feats
-                feats = torch.sum( feats * self.feature_combiner.unsqueeze(0).unsqueeze(0), dim=2)
 
-            prob_z_given_H = F.softmax(feats, dim=-1)
-            # print("prob_z_given_H : ", prob_z_given_H.size())
-            ret = prob_z_given_H # B x P
+                if self.use_structured_prior:
+                    embs = self.effect_type_emb(effects) # B,P,emsize
+                    effect_feature = self.effect_type_to_feature(embs) # B,P,1
+                    # print(torch.exp(effect_feature, dim=-1)) --> sort and analyze
+                    # print("feats : ", feats.size())
+                    # print("effect_feature : ", effect_feature.size())
+                    if self.use_structured_prior_binarypotential:
+                        effecthistory_feature = self.effecthistory_type_to_feature(
+                            torch.cat([embs,history_encodings],dim=2)) # B,P,1
+                        feats = torch.cat([feats.unsqueeze(2), effect_feature,effecthistory_feature], dim=2)  # B,P,num_feats
+                    else:
+                        feats = torch.cat([feats.unsqueeze(2), effect_feature], dim=2)  # B,P,num_feats
+                    feats = torch.sum( feats * self.feature_combiner.unsqueeze(0).unsqueeze(0), dim=2)
 
-            return ret
+                prob_z_given_H = F.softmax(feats, dim=-1)
+                # print("prob_z_given_H : ", prob_z_given_H.size())
+                ret = prob_z_given_H # B x P
+                return ret
+            except RuntimeError:
+                print("history.shape:", history.shape)
+                print("persona.shape:", persona.shape)
+                raise
 
     def sample(self, dist_over_z):
         '''
@@ -133,17 +149,35 @@ class PriorRobertaModel(nn.Module):
             return prob_z_given_H.to(self.args.device)
 
         else:
-            history_encodings = self.roberta_model(history)[1][-1][:, 0, :]  # B x 764
-            history_encodings = history_encodings.unsqueeze(1).repeat(1, persona.shape[1], 1)  # B x P x 764
+            try:
+                # print("history.shape, persona.shape:", history.shape, persona.shape)
+                history_encodings = self.roberta_model(history)[1][-1][:, 0, :]  # B x 764
+                history_encodings = history_encodings.unsqueeze(1).repeat(1, persona.shape[1], 1)  # B x P x 764
+                batch_size, num_personas, num_tokens = persona.shape
+                persona = persona.reshape(-1, num_tokens)
+                n = batch_size * num_personas
+                n_splits = 8
+                if n > 1 and n_splits > 1:
+                    split_size = n // n_splits
+                    persona_encodings = torch.cat(
+                        [
+                             self.roberta_model(persona[i*split_size:(i+1)*split_size, :])[1][-1][:, 0, :]
+                             for i in range(n_splits-1)
+                        ]
+                        + [self.roberta_model(persona[(n_splits-1)*split_size:, :])[1][-1][:, 0, :]],
+                        dim=0,
+                    ).reshape(batch_size, num_personas, -1)
+                else:
+                    persona_encodings = self.roberta_model(persona)[1][-1][:, 0, :].reshape(batch_size, num_personas, -1)
 
-            batch_size, num_personas, num_tokens = persona.shape
-            persona = persona.reshape(-1, num_tokens)
-            persona_encodings = self.roberta_model(persona)[1][-1][:, 0, :].reshape(batch_size, num_personas, -1)
+                norms = -1.0 * torch.norm(history_encodings - persona_encodings, 2, dim=-1)
+                prob_z_given_H = F.softmax(norms, dim=-1)
 
-            norms = -1.0 * torch.norm(history_encodings - persona_encodings, 2, dim=-1)
-            prob_z_given_H = F.softmax(norms, dim=-1)
-
-            return prob_z_given_H  # B x P
+                return prob_z_given_H  # B x P
+            except RuntimeError:
+                print("history.shape:", history.shape)
+                print("persona.shape:", persona.shape)
+                raise
 
     def sample(self, dist_over_z):
         '''
@@ -192,25 +226,43 @@ class InferenceRobertaModel(nn.Module):
             return prob_z_given_H_and_x.to(self.args.device)
 
         else:
+            try:
+                gt_response = mc_token_ids[:, :, 0]
 
-            gt_response = mc_token_ids[:, :, 0]
+                # print("history.shape, persona.shape, gt_response.shape:", history.shape, persona.shape, gt_response.shape)
+                if self.use_history:
+                    history_encodings = self.roberta_model(history)[1][-1][:, 0, :]  # B x 764
+                    history_encodings = history_encodings.unsqueeze(1).repeat(1, persona.shape[1], 1)  # B x P x 764
 
-            if self.use_history:
-                history_encodings = self.roberta_model(history)[1][-1][:, 0, :]  # B x 764
-                history_encodings = history_encodings.unsqueeze(1).repeat(1, persona.shape[1], 1)  # B x P x 764
+                gt_response_encodings = self.roberta_model(gt_response)[1][-1][:, 0, :]  # B x 764
 
-            gt_response_encodings = self.roberta_model(gt_response)[1][-1][:, 0, :]  # B x 764
+                batch_size, num_personas, num_tokens = persona.shape
+                persona = persona.reshape(-1, num_tokens)
+                n = batch_size * num_personas
+                n_splits = 8
+                if n > 1 and n_splits > 1:
+                    split_size = n // n_splits
+                    persona_encodings = torch.cat(
+                        [
+                             self.roberta_model(persona[i*split_size:(i+1)*split_size, :])[1][-1][:, 0, :]
+                             for i in range(n_splits-1)
+                        ]
+                        + [self.roberta_model(persona[(n_splits-1)*split_size:, :])[1][-1][:, 0, :]],
+                        dim=0,
+                    ).reshape(batch_size, num_personas, -1)
+                else:
+                    persona_encodings = self.roberta_model(persona)[1][-1][:, 0, :].reshape(batch_size, num_personas, -1)
+                if self.use_history:
+                    raise NotImplementedError
 
-            batch_size, num_personas, num_tokens = persona.shape
-            persona = persona.reshape(-1, num_tokens)
-            persona_encodings = self.roberta_model(persona)[1][-1][:, 0, :].reshape(batch_size, num_personas, -1)
-            if self.use_history:
-                raise NotImplementedError
-
-            norms = -1.0 * torch.norm(gt_response_encodings - persona_encodings, 2, dim=-1)
-            prob_z_given_H_and_x = F.softmax(norms, dim=-1)
-
-            return prob_z_given_H_and_x  # B x P
+                norms = -1.0 * torch.norm(gt_response_encodings - persona_encodings, 2, dim=-1)
+                prob_z_given_H_and_x = F.softmax(norms, dim=-1)
+                return prob_z_given_H_and_x  # B x P
+            except RuntimeError:
+                print("history.shape:", history.shape)
+                print("gt_response.shpae:", get_response.shape)
+                print("persona.shape:", persona.shape)
+                raise
 
     def sample(self, dist_over_z):
         '''

--- a/models/reinforce_model/train.py
+++ b/models/reinforce_model/train.py
@@ -187,7 +187,8 @@ def create_evaluator(args, model):
     metrics = {
         "nll": Loss(torch.nn.CrossEntropyLoss(ignore_index=-100), output_transform=lambda x: (x[0][0], x[1][0])),
         # the accuracy is a filler since multiple-choice is not used.
-        "accuracy": Accuracy(output_transform=lambda x: (torch.argmax(x[0][1].view((-1,)), dim=0, keepdim=True), x[1][1][:, 0])),
+        "accuracy": Accuracy(
+            output_transform=lambda x: (torch.argmax(x[0][1].view((-1,)), dim=0, keepdim=True), x[1][1][:, 0])),
         "ppl": Perplexity(output_transform=lambda x: (x[0][0], None)),
     }
 

--- a/models/reinforce_model/train.py
+++ b/models/reinforce_model/train.py
@@ -1,6 +1,7 @@
 import os
 import math
 import logging
+import random
 from pprint import pformat
 from argparse import ArgumentParser
 from collections import defaultdict
@@ -8,12 +9,18 @@ from itertools import chain
 from functools import partial
 from datetime import datetime
 
+import numpy as np
 import torch
+from apex import amp
+from torch.distributions import Categorical
 from torch.nn.parallel import DistributedDataParallel
-from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, TensorDataset
+from torch.utils.data.distributed import DistributedSampler
 from ignite.engine import Engine, Events
+from ignite.exceptions import NotComputableError
 from ignite.handlers import ModelCheckpoint
-from ignite.metrics import Accuracy, Loss, MetricsLambda, RunningAverage
+from ignite.metrics import Accuracy, Loss, Metric, MetricsLambda, RunningAverage
+from ignite.metrics.metric import sync_all_reduce, reinit__is_reduced
 from ignite.contrib.handlers import ProgressBar, PiecewiseLinear
 from ignite.contrib.handlers.tensorboard_logger import TensorboardLogger, OutputHandler, OptimizerParamsHandler
 from transformers import (AdamW, OpenAIGPTDoubleHeadsModel, OpenAIGPTTokenizer,
@@ -22,8 +29,43 @@ from transformers import (AdamW, OpenAIGPTDoubleHeadsModel, OpenAIGPTTokenizer,
 from models.reinforce_model.model_with_inferencenw import LatentVariableInferenceModel
 from models.reinforce_model.utils import get_dataset, make_logdir
 # from models.discrete_choice_model.data import get_data_loaders
-from models.reinforce_model.dataset import PersonaChatDataset, collate_dialog, MAX_NUM_PERSONA, MAX_NUM_COMET_PERSONA
+from models.reinforce_model.dataset import PersonaChatDataset, MAX_NUM_PERSONA, MAX_NUM_COMET_PERSONA
 from models.reinforce_model.data import PADDED_INPUTS, ATTR_TO_SPECIAL_TOKEN
+
+
+def seed_worker(worker_id):
+    worker_seed = torch.initial_seed() % 2**32
+    numpy.random.seed(worker_seed)
+    random.seed(worker_seed)
+
+
+class Perplexity(Metric):
+    def __init__(self, output_transform=lambda x: x, validate_args=True):
+        self.validate_args = validate_args
+        super(Perplexity, self).__init__(output_transform=output_transform)
+
+    @reinit__is_reduced
+    def reset(self):
+        self._num_distributions = torch.tensor(0, dtype=torch.int)
+        self._perplexities_sum = torch.tensor(0.0, dtype=torch.float)
+
+    @reinit__is_reduced
+    def update(self, output):
+        y_pred, _ = output
+        if y_pred.ndimension() != 2:
+            raise ValueError(f"Predictions (logits or probabilities has to have 2 dimensins. Got y_pred.shape={y_pred.shape}")
+        d = Categorical(None, y_pred, validate_args=self.validate_args)
+        ppl = d.perplexity()
+        self._perplexities_sum += ppl.sum()
+        self._num_distributions += ppl.numel()
+
+    @sync_all_reduce("_num_distributions", "_perplexities_sum") 
+    def compute(self):
+        if self._num_distributions.eq(0):
+            raise NotComputableError('Accuracy must have at least one example before it can be computed')
+        ppl = self._perplexities_sum / self._num_distributions
+        return ppl
+
 
 def average_distributed_scalar(scalar, args):
     """ Average a scalar over the nodes if we are in distributed training. We use this for distributed evaluation. """
@@ -33,12 +75,14 @@ def average_distributed_scalar(scalar, args):
     torch.distributed.all_reduce(scalar_t, op=torch.distributed.ReduceOp.SUM)
     return scalar_t.item()
 
+
 def add_special_tokens_(model, tokenizer):
     """ Add special tokens to the tokenizer and the model if they have not already been added. """
     orig_num_tokens = len(tokenizer.encoder)
     num_added_tokens = tokenizer.add_special_tokens(ATTR_TO_SPECIAL_TOKEN) # doesn't add if they are already there
     # if num_added_tokens > 0:
     model.gpt2_model.resize_token_embeddings(new_num_tokens=orig_num_tokens + num_added_tokens)
+
 
 '''
 deepy
@@ -69,11 +113,17 @@ def count_parameters(model):
     return sum(p.numel() for p in model.parameters() if p.requires_grad)
 
 
-def train():
+def get_args():
     parser = ArgumentParser()
     parser.add_argument("--dataset_path", type=str, default="", help="Path or url of the dataset. If empty download from S3.")
     parser.add_argument("--dataset_cache", type=str, default='persona_comet_weak_label_preprocessed', help="Path or url of the dataset cache")
-    parser.add_argument("--model_checkpoint", type=str, default="openai-gpt", help="Path, url or short name of the model")
+    parser.add_argument("--model_checkpoint", type=str, help="Path to `LatentVariableInferenceModel` weights.")
+    parser.add_argument(
+        "--generation_model", 
+        default="openai-gpt", 
+        help="The name of generator model. Available options are `gpt2` and `openai-gpt`. Default is `openai-gpt`.", 
+        choices=["gpt2", "openai-gpt"],
+    )
     parser.add_argument("--num_candidates", type=int, default=2, help="Number of candidates for training")
     parser.add_argument("--max_history", type=int, default=2, help="Number of previous exchanges to keep in history")
     parser.add_argument("--train_batch_size", type=int, default=4, help="Batch size for training")
@@ -108,99 +158,63 @@ def train():
     parser.add_argument("--use_structured_prior_binarypotential", action='store_true', default=False, help="")
     parser.add_argument("--effect_emb_dim", type=int, default=6, help="Embedding type while computing effect feature")
     args = parser.parse_args()
-
-    # logging is set to INFO (resp. WARN) for main (resp. auxiliary) process. logger.info => log main process only, logger.warning => log all processes
-    logging.basicConfig(level=logging.INFO if args.local_rank in [-1, 0] else logging.WARN)
-    print("Running process {}".format(args.local_rank))  # This is a logger.warning: it will be printed by all distributed processes
-    print("Arguments: {}".format(pformat(args)))
-
-    # Initialize distributed training if needed
-    args.distributed = (args.local_rank != -1)
-    if args.distributed:
-        torch.cuda.set_device(args.local_rank)
-        args.device = torch.device("cuda", args.local_rank)
-        torch.distributed.init_process_group(backend='nccl', init_method='env://')
-
-    print("Prepare tokenizer, pretrained model and optimizer.")
-    tokenizer_class = GPT2Tokenizer if "gpt2" in args.model_checkpoint else OpenAIGPTTokenizer # cant use Autotokenizer because checkpoint could be a Path
-    tokenizer = tokenizer_class.from_pretrained(args.model_checkpoint)
+    if not args.do_train and args.do_eval:
+        raise ValueError("You have to specify at least one of options `--do_train`, `--do_eval`")
+    return args
 
 
-    model_class = GPT2DoubleHeadsModel if "gpt2" in args.model_checkpoint else OpenAIGPTDoubleHeadsModel
-    if args.do_eval and not args.do_train:
-        print('Loading model from checkpoint {}'.format(args.model_checkpoint))
-    # model = model_class.from_pretrained(args.model_checkpoint)
-    # model.to(args.device)
-
-    model = LatentVariableInferenceModel(args, generator_class=model_class)
-    # model = LatentMarginalizedModel(args, generator_class=model_class)
-    print('Num parameters: {}'.format(count_parameters(model)))
-    model.to(args.device)
-
-    # Add special tokens if they are not already added
-    add_special_tokens_(model, tokenizer)
-    optimizer = AdamW(model.parameters(), lr=args.lr, correct_bias=True)
-
-    # Prepare model for FP16 and distributed training if needed (order is important, distributed should be the last)
-    if args.fp16:
-        from apex import amp  # Apex is only required if we use fp16 training
-        model, optimizer = amp.initialize(model, optimizer, opt_level=args.fp16)
-    if args.distributed:
-        model = DistributedDataParallel(model, device_ids=[args.local_rank], output_device=args.local_rank, find_unused_parameters=True)
-
-    print("Prepare datasets")
-    start = datetime.now()
-
-    train_dataset = PersonaChatDataset(args, tokenizer, split='train')
-    if args.do_eval:
-        val_dataset = PersonaChatDataset(args, tokenizer, split='valid')
-
-    train_sampler = torch.utils.data.sampler.RandomSampler(train_dataset)
-
-    if args.no_comet_persona:
-        max_num_persona = MAX_NUM_PERSONA
-    else:
-        max_num_persona = MAX_NUM_COMET_PERSONA
+def create_evaluator(args, model):
+    def inference(engine, batch):
+        model.eval()
+        with torch.no_grad():
+            batch = {name: input_tensor.to(args.device) for name, input_tensor in batch.items()}
+            lm_logits, mc_logits, *_ = model(
+                input_ids=batch["input_ids"],
+                token_type_ids=batch["token_type_ids"],
+                mc_token_ids=batch["mc_token_ids"],
+                lm_labels=batch["lm_labels"],
+                mc_labels=batch["mc_labels"],
+                persona=batch["persona"],
+                history=batch["history"],
+                effects=batch["effects"],
+            )
+            # print("(inference)mc_logits.shape, mc_labels.shape:", mc_logits.shape, batch["mc_labels"].shape)
+            lm_logits_flat_shifted = lm_logits[..., :-1, :].contiguous().view(-1, lm_logits.size(-1))
+            lm_labels_flat_shifted = batch["lm_labels"][:, 0, :, 1:].contiguous().view(-1)
+            return (lm_logits_flat_shifted, mc_logits), (lm_labels_flat_shifted, batch["mc_labels"])
     
-    train_loader = DataLoader(
-        train_dataset,
-        sampler=train_sampler,
-        batch_size=args.train_batch_size,
-        collate_fn=partial(collate_dialog, max_num_persona=max_num_persona),
-        pin_memory=True)
-    
-    if args.do_eval:
-        val_loader = DataLoader(
-            val_dataset,
-            shuffle=False,
-            batch_size=args.valid_batch_size,
-            collate_fn=partial(collate_dialog, max_num_persona=max_num_persona),
-            pin_memory=True)
+    evaluator = Engine(inference)
+    metrics = {
+        "nll": Loss(torch.nn.CrossEntropyLoss(ignore_index=-100), output_transform=lambda x: (x[0][0], x[1][0])),
+        # the accuracy is a filler since multiple-choice is not used.
+        "accuracy": Accuracy(output_transform=lambda x: (torch.argmax(x[0][1].view((-1,)), dim=0, keepdim=True), x[1][1][:, 0])),
+        "ppl": Perplexity(output_transform=lambda x: (x[0][0], None)),
+    }
 
-    print('{} - Data loaded. Starting training'.format(datetime.now() - start))
-    # train_loader, val_loader, train_sampler, valid_sampler = get_data_loaders(args, tokenizer)
+    for name, metric in metrics.items():
+        metric.attach(evaluator, name)
+    if args.local_rank in [-1, 0]:
+        pbar = ProgressBar(persist=True)
+        pbar.attach(evaluator)
+        evaluator.add_event_handler(Events.COMPLETED, lambda _: pbar.log_message("Validation: %s" % pformat(evaluator.state.metrics)))
+    return evaluator
 
-    # Training function and trainer
-    def update(engine, batch):
-        
+
+def create_trainer_and_checkpoint_handler(args, model, optimizer, train_loader, val_loader, evaluator, log_dir):
+    def update(engine, batch):        
         model.train()
-
-        batch = tuple(input_tensor.to(args.device) for input_tensor in batch)
-        input_ids, token_type_ids, lm_labels, mc_token_ids, mc_labels, persona, history, effects = batch
-        
-        (lm_loss), (mc_loss), (loss_prior), (conditional_lm_loss), (num_labels), (track_rewards), (kl_loss), (elbo_loss_tracking) = model(
-            input_ids=input_ids,
-            token_type_ids=token_type_ids,
-            mc_token_ids=mc_token_ids,
-            lm_labels=lm_labels,
-            mc_labels=mc_labels,
-            persona=persona,
-            history=history,
-            effects=effects
+        batch = {name: input_tensor.to(args.device) for name, input_tensor in batch.items()}
+        _, _, lm_loss, mc_loss, loss_prior, conditional_lm_loss, num_labels, track_rewards, kl_loss, elbo_loss_tracking = model(
+            input_ids=batch["input_ids"],
+            token_type_ids=batch["token_type_ids"],
+            mc_token_ids=batch["mc_token_ids"],
+            lm_labels=batch["lm_labels"],
+            mc_labels=batch["mc_labels"],
+            persona=batch["persona"],
+            history=batch["history"],
+            effects=batch["effects"],
         )
-
         loss = (lm_loss * args.lm_coef + mc_loss * args.mc_coef) / args.gradient_accumulation_steps
-        
         if args.fp16:
             with amp.scale_loss(loss, optimizer) as scaled_loss:
                 scaled_loss.backward()
@@ -208,49 +222,14 @@ def train():
         else:
             loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), args.max_norm)
-        
         if engine.state.iteration % args.gradient_accumulation_steps == 0:
             optimizer.step()
             optimizer.zero_grad()
-
         return loss.item(), lm_loss.item(), mc_loss.item(), loss_prior.item(), conditional_lm_loss.item(), track_rewards.item(), kl_loss.item(), elbo_loss_tracking.item()
     
     trainer = Engine(update)
-
-    # Evaluation function and evaluator (evaluator output is the input of the metrics)
-    def inference(engine, batch):
-    
-        model.eval()
-    
-        with torch.no_grad():
-    
-            batch = tuple(input_tensor.to(args.device) for input_tensor in batch)
-            input_ids, mc_token_ids, lm_labels, mc_labels, token_type_ids = batch
-    
-            # print(tokenizer.decode(input_ids[0, -1, :].tolist()))
-            # if we dont send labels to model, it doesnt return losses
-    
-            lm_logits, mc_logits, *_ = model(
-                input_ids, token_type_ids=token_type_ids, mc_token_ids=mc_token_ids,
-            )
-    
-            lm_logits_flat_shifted = lm_logits[..., :-1, :].contiguous().view(-1, lm_logits.size(-1))
-            lm_labels_flat_shifted = lm_labels[..., 1:].contiguous().view(-1)
-    
-            return (lm_logits_flat_shifted, mc_logits), (lm_labels_flat_shifted, mc_labels)
-    
-    evaluator = Engine(inference)
-
-    # Make sure distributed data samplers split the dataset nicely between the distributed processes
-    # if args.distributed:
-    #     trainer.add_event_handler(Events.EPOCH_STARTED, lambda engine: train_sampler.set_epoch(engine.state.epoch))
-    #     evaluator.add_event_handler(Events.EPOCH_STARTED, lambda engine: valid_sampler.set_epoch(engine.state.epoch))
-
-    # Linearly decrease the learning rate from lr to zero
     scheduler = PiecewiseLinear(optimizer, "lr", [(0, args.lr), (args.n_epochs * len(train_loader), 0.0)])
     trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
-
-    # Prepare metrics - note how we compute distributed metrics
     RunningAverage(output_transform=lambda x: x[0]).attach(trainer, "loss")
     RunningAverage(output_transform=lambda x: x[1]).attach(trainer, "lm_loss")
     RunningAverage(output_transform=lambda x: x[2]).attach(trainer, "mc_loss")
@@ -259,67 +238,143 @@ def train():
     RunningAverage(output_transform=lambda x: x[5]).attach(trainer, "rewards")
     RunningAverage(output_transform=lambda x: x[6]).attach(trainer, "kl_loss")
     RunningAverage(output_transform=lambda x: x[7]).attach(trainer, "elbo_loss")
-
-    metrics = {
-        "nll": Loss(torch.nn.CrossEntropyLoss(ignore_index=-100), output_transform=lambda x: (x[0][0], x[1][0])),
-        "accuracy": Accuracy(output_transform=lambda x: (x[0][1], x[1][1]))}
-
-    metrics.update(
-        {"average_nll": MetricsLambda(average_distributed_scalar, metrics["nll"], args),
-        "average_accuracy": MetricsLambda(average_distributed_scalar, metrics["accuracy"], args)})
-
-    metrics["average_ppl"] = MetricsLambda(math.exp, metrics["average_nll"])
-
-    for name, metric in metrics.items():
-        metric.attach(evaluator, name)
-
-    # On the main process: add progress bar, tensorboard, checkpoints and save model, configuration and tokenizer before we start to train
-    def print_model_save(engine):
-        print("Training complete. Saving Model.")
-    
-    def print_validation(engine):
-        print("Model saved. Starting validation.")
-
     if args.local_rank in [-1, 0]:
         pbar = ProgressBar(persist=True)
         pbar.attach(trainer, metric_names=["loss", "lm_loss", "mc_loss", "prior_loss", "cond_lm_loss", "rewards", "kl_loss", "elbo_loss"])
-        evaluator.add_event_handler(Events.COMPLETED, lambda _: pbar.log_message("Validation: %s" % pformat(evaluator.state.metrics)))
-
-        log_dir = make_logdir(args.model_checkpoint, args.exp_name)
-        log_dir = os.path.join(args.log_dir, log_dir)
-
-        print("Logging at log dir: {}".format(log_dir))
-
-        # save model checkpoints
         checkpoint_handler = ModelCheckpoint(log_dir, 'checkpoint', save_interval=1, n_saved=None)
-        trainer.add_event_handler(Events.EPOCH_COMPLETED, print_model_save)
+        trainer.add_event_handler(Events.EPOCH_COMPLETED, lambda: print("Training complete. Saving Model."))
         trainer.add_event_handler(Events.EPOCH_COMPLETED, checkpoint_handler, {'mymodel': getattr(model, 'module', model)})  # "getattr" takes care of distributed encapsulation
+        trainer.add_event_handler(Events.EPOCH_COMPLETED, lambda: print("Model saved. Starting validation."))
+    else:
+        checkpoint_handler = None
+    if args.do_eval:
+        assert evaluator is not None
+        trainer.add_event_handler(Events.EPOCH_COMPLETED, lambda _: evaluator.run(val_loader))
+        if args.n_epochs < 1:
+            trainer.add_event_handler(Events.COMPLETED, lambda _: evaluator.run(val_loader))
+        if args.eval_before_start:
+            trainer.add_event_handler(Events.STARTED, lambda _: evaluator.run(val_loader))
+    return trainer, checkpoint_handler
 
+
+def create_model_and_optimizer(args, tokenizer):
+    model_class = GPT2DoubleHeadsModel if "gpt2" in args.generation_model else OpenAIGPTDoubleHeadsModel
+
+    model = LatentVariableInferenceModel(args, generator_class=model_class)
+    print('Num parameters: {}'.format(count_parameters(model)))
+    model.to(args.device)
+    if args.model_checkpoint is not None:
+        print('Loading model from checkpoint {}'.format(args.model_checkpoint))
+        model_weights = torch.load(args.model_checkpoint, map_location=args.device)
+        model.load_state_dict(model_weights)
+    add_special_tokens_(model, tokenizer)
+    if args.do_train:
+        optimizer = AdamW(model.parameters(), lr=args.lr, correct_bias=True)
+    else:
+        optimizer = None
+    if args.fp16 and args.do_train:
+        model, optimizer = amp.initialize(model, optimizer, opt_level=args.fp16)
+    if args.local_rank != -1:
+        model = DistributedDataParallel(model, device_ids=[args.local_rank], output_device=args.local_rank, find_unused_parameters=True)
+    return model, optimizer   
+
+
+def create_tokenizer(args):
+    tokenizer_class = GPT2Tokenizer if "gpt2" in args.generation_model else OpenAIGPTTokenizer # cant use Autotokenizer because checkpoint could be a Path
+    tokenizer = tokenizer_class.from_pretrained(args.generation_model)
+    return tokenizer
+
+
+def init_distributed(args):
+    torch.cuda.set_device(args.local_rank)
+    args.device = torch.device("cuda", args.local_rank)
+    torch.distributed.init_process_group(backend='nccl', init_method='env://')
+
+
+def create_val_dataloader(args, tokenizer, max_num_persona):
+    val_dataset = PersonaChatDataset(args, tokenizer, split='valid')
+    if args.local_rank == -1:
+        val_sampler = SequentialSampler(val_dataset)
+    else:
+        val_sampler = DistributedSampler(val_dataset)
+    val_loader = DataLoader(
+        val_dataset,
+        shuffle=False,
+        batch_size=args.valid_batch_size,
+        collate_fn=partial(val_dataset.collate_dialog, max_num_persona=max_num_persona),
+        pin_memory=True,
+        sampler=val_sampler,
+    )
+    return val_loader
+
+
+def create_train_dataloader(args, tokenizer, max_num_persona):
+    train_dataset = PersonaChatDataset(args, tokenizer, split='train')
+    if args.local_rank == -1:
+        train_sampler = RandomSampler(train_dataset)
+    else:
+        train_sampler = DistributedSampler(train_dataset)
+    train_loader = DataLoader(
+        train_dataset,
+        sampler=train_sampler,
+        batch_size=args.train_batch_size,
+        collate_fn=partial(train_dataset.collate_dialog, max_num_persona=max_num_persona),
+        pin_memory=True,
+        worker_init_fn=seed_worker,
+    )
+    return train_loader
+
+
+def train():
+    args = get_args()
+    logging.basicConfig(level=logging.INFO if args.local_rank in [-1, 0] else logging.WARN)
+    print("Running process {}".format(args.local_rank))
+    print("Arguments: {}".format(pformat(args)))
+
+    if args.local_rank != -1:
+        init_distributed(args)
+    print("Prepare tokenizer, pretrained model and optimizer.")
+    tokenizer = create_tokenizer(args)
+    model, optimizer = create_model_and_optimizer(args, tokenizer)
+
+    print("Prepare datasets")
+    start = datetime.now()
+    max_num_persona = MAX_NUM_PERSONA if args.no_comet_persona else MAX_NUM_COMET_PERSONA
+
+    log_dir = make_logdir(args.generation_model, args.exp_name)
+    log_dir = os.path.join(args.log_dir, log_dir)
+    if args.local_rank in [-1, 0]:
+        os.makedirs(log_dir, exist_ok=True)
+        print("Logging at log dir: {}".format(log_dir))
         torch.save(args, log_dir + '/model_training_args.bin')
-        # getattr(model, 'module', model).config.to_json_file(os.path.join(log_dir, CONFIG_NAME))
         tokenizer.save_pretrained(log_dir)
 
-        # Attach evaluation to trainer: we evaluate when we start the training and at the end of each epoch
-        trainer.add_event_handler(Events.EPOCH_COMPLETED, print_validation)
-        if args.do_eval:
-            trainer.add_event_handler(Events.EPOCH_COMPLETED, lambda _: evaluator.run(val_loader))
-            if args.n_epochs < 1:
-                trainer.add_event_handler(Events.COMPLETED, lambda _: evaluator.run(val_loader))
-            if args.eval_before_start:
-                trainer.add_event_handler(Events.STARTED, lambda _: evaluator.run(val_loader))
+    if args.do_eval:
+        val_loader = create_val_dataloader(args, tokenizer, max_num_persona)
+        evaluator = create_evaluator(args, model)
+    else:
+        val_loader, evaluator = None, None
+    if args.do_train:
+        train_loader = create_train_dataloader(args, tokenizer, max_num_persona)
+        trainer, checkpoint_handler = create_trainer_and_checkpoint_handler(args, model, optimizer, train_loader, val_loader, evaluator, log_dir)
+    else:
+        train_loader, trainer = None, None
 
-    # Run the training
+    print('{} - Data loaded. Starting training'.format(datetime.now() - start))
+
+
     if args.do_train:
         trainer.run(train_loader, max_epochs=args.n_epochs)
     if args.do_eval and not args.do_train:
         print('Running only Evaluation. No Training.')
         evaluator.run(val_loader)
-
-
     # On the main process: close tensorboard logger and rename the last checkpoint (for easy re-loading with OpenAIGPTModel.from_pretrained method)
     if args.local_rank in [-1, 0] and args.n_epochs > 0 and args.do_train:
+        assert checkpoint_handler is not None
         os.rename(os.path.join(log_dir, checkpoint_handler._saved[-1][1]), os.path.join(log_dir, WEIGHTS_NAME))  # TODO: PR in ignite to have better access to saved file paths (cleaner)
         # tb_logger.close()
 
 if __name__ == "__main__":
+    np.random.seed(42)
+    #torch.use_deterministic_algorithms()
     train()

--- a/models/reinforce_model/utils.py
+++ b/models/reinforce_model/utils.py
@@ -83,7 +83,7 @@ def make_logdir(model_name: str, exp_name: str):
     # Code copied from ignite repo
     current_time = datetime.now().strftime('%b%d_%H-%M-%S')
     logdir = os.path.join(
-        'runs', current_time + '_' + socket.gethostname() + '_' + model_name + exp_name)
+        'runs', current_time + '_' + socket.gethostname() + '_' + model_name + '_' + exp_name)
     return logdir
 
 


### PR DESCRIPTION
1. Add logits to `LatentVariableInferenceModel.forward` in order to                                                     
   perform validation.                                                                                                  
Pytorch Ignite Engine for evaluation demands and inference function which will return logits.                           
                                                                                                                        
2. Refactor `train()` function.                                                                                         
                                                                                                                        
3. Fix perplexity computation. Perplexity is not exponent of loss (cross entropy) but an                                
   exponent of entropy.                                                                                                 
Create a pytorch ignite metric                                                                                          
                                                                                                                        
4. Replace `RandomSampler` with `DistributedSampler` for distributed data parallel case                                 
`DistrubutedSampler` splits selects only a part of data whereas `RandomSampler` loads all                               
dataset. If `RandomSampler` is used 1 epoch actually consists of nproc epochs. And there                                
can be repeated elements in a batch.                                                                                    
                                                                                                                        
5. Require at least one of options `--do_train`, `--do_eval`                                                            
                                                                                                                        
6. Do not create objects if they are not used. For instance, if no evaluation is                                           
performed, `evaluator` is not created.                                                                                  
                                                                                                                        
7. Do evaluation in parallel if distributed data parallel mode is used.                                                 
                                                                                                                        
6. Make batch a dictionary                                                                                              
It is difficult to maintain the order of model inputs in the dataset, collate function                                  
and train function. So now the batch is a dictionary.                                                                   
                                                                                                                           
7. Remove `history_folded` entirely since it is not used.                                                                
                                                                                                                           
8. Make `collate_dialog()` function a dataset method.                                                                      
This allows to make `num_candidates` an attribute and remove it from samples and batch.                                    
                                                                                                                           
9. The elements of `PersonaChatDataset.dataset[key]` where key is one of `'input_ids'`,                                      
   `'token_type_ids'`, `'mc_token_ids'`, `'lm_labels'`, `'mc_labels'` are now ready samples.                                       
   No slicing is needed to get an element.                                                                                 
                                                                                                                           
10. Remove max_num_persona. The number of personas in a batch can vary now.                                                
Previously there always were max_num_persona personas in a batch regardless of                                             
`num_beams`. That lead to high GPU memory usage and slowed down computations.                                              
                                                                                                                           
11. Fix `num_labels` local variable in `LatentVariableInferenceModel.forward()`.                                           
Previously it became equal to zero if `--num_candidates` was greater than 1.